### PR TITLE
PhantomJS hard dependency

### DIFF
--- a/lib/local/platform/macos.js
+++ b/lib/local/platform/macos.js
@@ -73,8 +73,6 @@ var browsers = supportedBrowsers.map(function (browser) {
 	return function(callback) {
 		var current = _.extend({}, browser);
 		exec(current.pathQuery, function (err, stdout) {
-			if (err) return callback(err);
-
 			if (!stdout.length) {
 				// Not found using mdfind, let's see if the standard path exists
 				if(browser.defaultLocation && fs.existsSync(browser.defaultLocation)) {


### PR DESCRIPTION
Currently on MacOS(windows untested), if phantom is uninstalled, launchpad is unable to serve any requests.
