### PR TITLE
Add support for Node webkit in MacOS

### DIFF
--- a/lib/local/index.js
+++ b/lib/local/index.js
@@ -42,7 +42,15 @@ module.exports = function (settings, callback) {
         args = args.concat(cleanLaunch[name]);
       }
 
-      return Q.ninvoke(instance, 'start', browser.command, args.concat(url), settings, browser);
+      // Convert the command if set (some browsers need some customization)
+      if(browser.getCommand) {
+        browser.command = browser.getCommand(browser, url, args);
+        args = null;
+      } else {
+        args = args.concat(url);
+      }
+
+      return Q.ninvoke(instance, 'start', browser.command, args, settings, browser);
     }).nodeify(callback);
   }
 

--- a/lib/local/instance.js
+++ b/lib/local/instance.js
@@ -25,7 +25,7 @@ var getProcessId = function (name, callback) {
 var Instance = function (cmd, args, settings, options) {
   this.options = options || {};
   var self = this;
-  var childProcess = spawn(cmd, args, settings || {});
+  var childProcess = args === null ? exec(cmd, settings || {}) : spawn(cmd, args, settings || {});
 
   childProcess.on('exit', function (code, signal) {
     self.emit('stop', {
@@ -66,7 +66,7 @@ Instance.prototype.stop = function (callback) {
     });
   }
 
-  if (this.options.command === 'open') {
+  if (this.options.command.indexOf('open') === 0) {
     exec('osascript -e \'tell application "' + self.options.process + '" to quit\'');
   } else if (process.platform === 'win32') {
     exec('taskkill /IM ' + (this.options.imageName || path.basename(this.cmd)))

--- a/lib/local/platform/macos.js
+++ b/lib/local/platform/macos.js
@@ -60,5 +60,16 @@ module.exports = {
     args: [path.join(__dirname, '..', '..', '..', 'resources/phantom.js')],
     defaultLocation: '/usr/local/bin/phantomjs',
     multi: true
+  },
+  nodeWebkit: {
+    pathQuery: 'mdfind \'kMDItemDisplayName == "node-webkit" && kMDItemKind == Application\'',
+    command: 'open',
+    process: 'node-webkit',
+    versionKey: 'CFBundleShortVersionString',
+    defaultLocation: '/Applications/node-webkit.app',
+    args: ['--args' ],
+    getCommand: function(browser, url, args) {
+      return browser.command + ' ' + args.join(' ') + ' --url="' + url + '"';
+    }
   }
-}
+};

--- a/lib/local/version.js
+++ b/lib/local/version.js
@@ -48,5 +48,7 @@ module.exports = function(browser) {
       browser.version = version;
     }
     return browser;
+  }, function() {
+    return browser;
   });
 }

--- a/test/local.js
+++ b/test/local.js
@@ -4,7 +4,8 @@ var local = require('../lib/local');
 var useragent = require('useragent');
 var familyMapping = {
   canary: 'chrome',
-  phantom: 'phantomjs'
+  phantom: 'phantomjs',
+  nodeWebkit: 'chrome'
 }
 var server = http.createServer(function (req, res) {
   res.writeHead(200, {'Content-Type': 'text/plain'});


### PR DESCRIPTION
This pull request adds support for node-webkit as a browser on MacOS so people can easily test their node-webkit applications.
