### PR TITLE
Allow browsers to start multiple times even if they are already running.

### DIFF
--- a/lib/local/instance.js
+++ b/lib/local/instance.js
@@ -60,6 +60,11 @@ Instance.prototype.getPid = function (callback) {
 
 Instance.prototype.stop = function (callback) {
   var self = this;
+
+  if(self.running) {
+    return callback(null, {});
+  }
+
   if (callback) {
     this.once('stop', function (data) {
       callback(null, data);
@@ -98,10 +103,18 @@ exports.start = function (cmd, args, settings, options, callback) {
   // can only launch once
   if (options.process && !options.multi) {
     getProcessId(options.process, function (err, pid) {
-      if (!err) {
+      if (!err && !options.opensTab) {
         return callback(new Error(options.process + ' seems already running with process id ' + pid));
       }
-      return callback(null, getInstance());
+
+      var instance = getInstance();
+
+      // Add a `running` flag if the browser is already running but can open a new tab
+      if(!err && options.opensTab) {
+        instance.running = true;
+      }
+
+      return callback(null, instance);
     });
   } else {
     callback(null, getInstance());

--- a/lib/local/platform/macos.js
+++ b/lib/local/platform/macos.js
@@ -8,7 +8,8 @@ module.exports = {
     process: 'Google Chrome',
     versionKey: 'KSVersion',
     defaultLocation: '/Applications/Google Chrome.app',
-    args: ['--args']
+    args: ['--args'],
+    opensTab: true
   },
   canary: {
     pathQuery: 'mdfind \'kMDItemDisplayName == "Google Chrome Canary" && kMDItemKind == Application\'',
@@ -17,7 +18,8 @@ module.exports = {
     process: 'Google Chrome Canary',
     versionKey: 'KSVersion',
     defaultLocation: '/Applications/Google Chrome Canary.app',
-    args: ['--args']
+    args: ['--args'],
+    opensTab: true
   },
   firefox: {
     pathQuery: 'mdfind \'kMDItemDisplayName == "Firefox" && kMDItemKind == Application\'',
@@ -26,7 +28,8 @@ module.exports = {
     process: 'firefox',
     versionKey: 'CFBundleGetInfoString',
     defaultLocation: '/Applications/Firefox.app',
-    args: ['--args']
+    args: ['--args'],
+    opensTab: true
   },
   aurora: {
     pathQuery: 'mdfind \'kMDItemDisplayName == "FirefoxAurora" && kMDItemKind == Application\'',
@@ -35,7 +38,8 @@ module.exports = {
     process: 'firefox',
     versionKey: 'CFBundleGetInfoString',
     defaultLocation: '/Applications/FirefoxAurora.app',
-    args: ['--args']
+    args: ['--args'],
+    opensTab: true
   },
   opera: {
     pathQuery: 'mdfind \'kMDItemDisplayName == "Opera" && kMDItemKind == Application\'',
@@ -52,7 +56,8 @@ module.exports = {
     command: 'open',
     process: 'Safari',
     versionKey: 'CFBundleShortVersionString',
-    defaultLocation: '/Applications/Safari.app'
+    defaultLocation: '/Applications/Safari.app',
+    opensTab: true
   },
   phantom: {
     pathQuery: 'which phantomjs',

--- a/lib/local/platform/unix.js
+++ b/lib/local/platform/unix.js
@@ -3,11 +3,13 @@ var path = require('path');
 module.exports = {
   chrome: {
     pathQuery: 'which google-chrome',
-    process: 'chrome'
+    process: 'chrome',
+    opensTab: true
   },
   firefox: {
     pathQuery: 'which firefox',
-    process: 'firefox'
+    process: 'firefox',
+    opensTab: true
   },
   opera: {
     pathQuery: 'which opera',

--- a/lib/local/platform/windows.js
+++ b/lib/local/platform/windows.js
@@ -8,7 +8,8 @@ module.exports = {
   chrome: {
     defaultLocation: path.join(appData, 'Google', 'Chrome', 'Application', 'chrome.exe') ,
     pathQuery: 'dir /s /b chrome.exe',
-    cwd: cwd
+    cwd: cwd,
+    opensTab: true
   },
   canary: {
     defaultLocation: path.join(appData, 'Google', 'Chrome SxS', 'Application', 'chrome.exe')
@@ -16,10 +17,12 @@ module.exports = {
   firefox: {
     defaultLocation: path.join(programFiles, 'Mozilla Firefox', 'firefox.exe'),
     pathQuery: 'dir /s /b firefox.exe',
-    cwd: cwd
+    cwd: cwd,
+    opensTab: true
   },
   aurora: {
-    defaultLocation: path.join(programFiles, 'Aurora', 'firefox.exe')
+    defaultLocation: path.join(programFiles, 'Aurora', 'firefox.exe'),
+    opensTab: true
   },
   opera: {
     defaultLocation: path.join(programFiles, 'Opera', 'launcher.exe'),


### PR DESCRIPTION
This pull request allows to launch a browser again even if it is already running. All recent browsers now just open a new tab in that case. Launchpad will not try to close the browser if it has been running already. Closes #29.
