### PR TITLE
instance.stop() requires a callback to be passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,12 @@ launch.browserstack({
     browserstack.ie('http://url', function(err, instance) {
       // Shut the instance down after 5 seconds
       setTimeout(function() {
-        instance.stop();
+        instance.stop(function (err) {
+          if(err) {
+            console.log(err);
+          }
+          console.log('Browser instance has stopped');
+        });
       }, 5000);
   });
 });


### PR DESCRIPTION
Hey, just was following throw the code and notices that .stop() requires a callback so I updated the readme accordingly, hope it helps avoid some questions in the future:)
