### PR TITLE
Open Firefox in private mode on Unix.

### DIFF
--- a/lib/local/instance.js
+++ b/lib/local/instance.js
@@ -30,7 +30,7 @@ var Instance = function (cmd, args, settings, options) {
   var self = this;
   var childProcess = args === null ? exec(cmd, settings || {}) : spawn(cmd, args, settings || {});
 
-  debug( (args === null ? 'exec' : 'span') + ' child process with process id',
+  debug( (args === null ? 'exec' : 'spawn') + ' child process with process id',
     childProcess.pid, cmd, args);
 
   childProcess.on('exit', function (code, signal) {

--- a/lib/local/platform/unix.js
+++ b/lib/local/platform/unix.js
@@ -9,6 +9,9 @@ module.exports = {
   firefox: {
     pathQuery: 'which firefox',
     process: 'firefox',
+    // See https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options
+    // Assuming Firefox >= 20
+    args: ['--private-window'],
     opensTab: true
   },
   opera: {


### PR DESCRIPTION
This makes sure to open Firefox in private windows on Unix (see https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options). Hopefully that will fix it crashing when opened multiple times.