### PR TITLE
Add '--no-first-run' option for Chrome in unix.js

### DIFF
--- a/lib/local/platform/unix.js
+++ b/lib/local/platform/unix.js
@@ -4,7 +4,8 @@ module.exports = {
   chrome: {
     pathQuery: 'which google-chrome',
     process: 'chrome',
-    opensTab: true
+    opensTab: true,
+    args: ['--no-first-run']
   },
   firefox: {
     pathQuery: 'which firefox',


### PR DESCRIPTION
This is that the tests can be run on Chrome in CI environments like travis.