### PR TITLE
Added the option to pass args to local browsers

### DIFF
--- a/lib/local/index.js
+++ b/lib/local/index.js
@@ -45,6 +45,10 @@ module.exports = function (settings, callback) {
         args = args.concat(cleanLaunch[name]);
       }
 
+      if(options.args) {
+        args = args.concat(options.args);
+      }
+      
       // Convert the command if set (some browsers need some customization)
       if(browser.getCommand) {
         browser.command = browser.getCommand(browser, url, args, options);


### PR DESCRIPTION
Fixes #41

Example:

```
var options = {
   args: ['--remote-debugging-port=9222']
}

local.chrome(url, options, function(err, instance) {
})
```