### PR TITLE
Fixed ShowVer.exe with spaces in path

### DIFF
--- a/lib/local/version.js
+++ b/lib/local/version.js
@@ -13,7 +13,7 @@ module.exports = function(browser) {
 
   // Run ShowVer.exe and parse out ProductVersion key (Windows)
   if (process.platform === 'win32') {
-    var command = path.join(__dirname, '..', '..', 'resources', 'ShowVer.exe "' + browser.command + '"');
+    var command = path.join('"' + __dirname, '..', '..', 'resources', 'ShowVer.exe" "' + browser.command + '"');
     var deferred = Q.defer();
 
     debug('Retrieving version for windows executable', command);


### PR DESCRIPTION
If ShowVer.exe resides in a location that includes spaces in the path the command would fail.