### PR TITLE
Add launching of the Edge browser

### DIFF
--- a/lib/local/platform/windows.js
+++ b/lib/local/platform/windows.js
@@ -1,6 +1,14 @@
 var os = require('os');
+var fs = require('fs');
 var path = require('path');
 var programFiles = os.arch() === "x64" ? process.env["ProgramFiles(x86)"] : process.env.ProgramFiles;
+var windowsDirectory = process.env.winDir;
+var systemApps = path.join(windowsDirectory, 'SystemApps');
+var microsoftEdgeDirectory = fs.readdirSync(systemApps).filter(function(folder) {
+    return folder.startsWith('Microsoft.MicrosoftEdge');
+  }).map(function(folder) {
+    return path.join(systemApps, folder);
+  })[0];
 var cwd = path.dirname(programFiles);
 var appData = appData || process.env.APPDATA;
 
@@ -34,6 +42,14 @@ module.exports = {
   ie: {
     defaultLocation: path.join(programFiles, 'Internet Explorer', 'iexplore.exe'),
     pathQuery: 'dir /s /b iexplore.exe',
+    cwd: cwd
+  },
+  edge: {
+    defaultLocation: path.join(microsoftEdgeDirectory, 'MicrosoftEdge.exe'),
+    getCommand: function(browser, url) {
+      return 'start /wait microsoft-edge:' + url;
+    },
+    opensTab: true,
     cwd: cwd
   },
   phantom: {


### PR DESCRIPTION
Attempts to resolve #61.

I've had a look into this as I'd like to get Polymer/web-components-tester working with Edge. I can find the executable like this:

```js
var windowDirectory = process.env.winDir;
var systemApps = path.json(windowsDirectory, 'SystemApps');
var edgeDirectory = fs.readdirSync(systemApps)
  .filter(function(folder) {
    return folder.startsWith('Microsoft.MicrosoftEdge');
  })
  .map(function(folder) {
    return path.json(systemApps, folder);
  })[0];
```

However, this is pretty useless and running the executable doesn't do anything as it's a Windows Store application. It seems you load a web page with:

```
> start microsoft-edge:https://github.com
```

The following works:

```
> python -m http.server 8000
> start microsoft-edge:https://localhost:8000
```

So I just need to figure out what needs to go into the `platform/windows.js` file.