### PR TITLE
Refactor code for finding the Edge directory

### DIFF
--- a/lib/local/platform/windows.js
+++ b/lib/local/platform/windows.js
@@ -2,13 +2,6 @@ var os = require('os');
 var fs = require('fs');
 var path = require('path');
 var programFiles = os.arch() === "x64" ? process.env["ProgramFiles(x86)"] : process.env.ProgramFiles;
-var windowsDirectory = process.env.winDir;
-var systemApps = path.join(windowsDirectory, 'SystemApps');
-var microsoftEdgeDirectory = fs.readdirSync(systemApps).filter(function(folder) {
-    return folder.startsWith('Microsoft.MicrosoftEdge');
-  }).map(function(folder) {
-    return path.join(systemApps, folder);
-  })[0];
 var cwd = path.dirname(programFiles);
 var appData = appData || process.env.APPDATA;
 
@@ -45,7 +38,7 @@ module.exports = {
     cwd: cwd
   },
   edge: {
-    defaultLocation: path.join(microsoftEdgeDirectory, 'MicrosoftEdge.exe'),
+    defaultLocation: path.join(getEdgeDirectory(), 'MicrosoftEdge.exe'),
     getCommand: function(browser, url) {
       return 'start /wait microsoft-edge:' + url;
     },
@@ -77,4 +70,19 @@ function altPaths() {
     path.join.apply(path, [programFiles].concat(args)),
     path.join.apply(path, [appData].concat(args))
   ];
+}
+
+function getEdgeDirectory() {
+  var windowsDirectory = process.env.winDir;
+  var systemApps = path.join(windowsDirectory, 'SystemApps');
+
+  try {
+    return fs.readdirSync(systemApps).filter(function(folder) {
+        return folder.startsWith('Microsoft.MicrosoftEdge');
+      }).map(function(folder) {
+        return path.join(systemApps, folder);
+      })[0];
+  } catch(ex) {
+    return systemApps;
+  }
 }


### PR DESCRIPTION
The Edge directory has a dynamic name, so we must find it by looking
inside of a SystemApps folder, that will not exist on all versions of
Windows. This commit refactors that code so that it will not throw on
systems not containing such a folder. Closes #65